### PR TITLE
fix: prevent labels from being re-added if they've been removed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -154,7 +154,7 @@ export default {
       });
     }
 
-    for (const label of labels) {
+    for (const label of filteredLabels) {
       // If the label isn't on the PR, there is no need to remove it
       if (!pr.pull_request.labels.find((l) => l.name === label)) {
         continue;


### PR DESCRIPTION
## Description
Labels that were manually removed would be added back to PRs. This adds some additional lines of code, but I think it's worth fixing this.

## Major Changes
- `uniqueAddedLabels` will keep track of labels that have been added. Labels that have been removed will have to be manually added back on.
- `labels` is now a `Set()` instead of managing two different arrays